### PR TITLE
fix JSON flaky tests

### DIFF
--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/EmitterTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/EmitterTest.java
@@ -240,12 +240,14 @@ public class EmitterTest
                 request.getHeaders().get(HttpHeaders.Names.CONTENT_TYPE)
             );
             Assert.assertEquals(
-                StringUtils.format(
+                JSON_MAPPER.readTree(StringUtils.format(
                     "[%s,%s]\n",
                     JSON_MAPPER.writeValueAsString(events.get(0)),
                     JSON_MAPPER.writeValueAsString(events.get(1))
-                ),
-                StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )),
+                JSON_MAPPER.readTree(
+                    StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )
             );
 
             return GoHandlers.immediateFuture(okResponse());
@@ -282,12 +284,14 @@ public class EmitterTest
                 request.getHeaders().get(HttpHeaders.Names.CONTENT_TYPE)
             );
             Assert.assertEquals(
-                StringUtils.format(
+                JSON_MAPPER.readTree(StringUtils.format(
                     "[%s,%s]\n",
                     JSON_MAPPER.writeValueAsString(events.get(0)),
                     JSON_MAPPER.writeValueAsString(events.get(1))
-                ),
-                StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )),
+                JSON_MAPPER.readTree(
+                    StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )
             );
 
             return GoHandlers.immediateFuture(okResponse());
@@ -467,12 +471,14 @@ public class EmitterTest
                 request.getHeaders().get(HttpHeaders.Names.AUTHORIZATION)
             );
             Assert.assertEquals(
-                StringUtils.format(
+                JSON_MAPPER.readTree(StringUtils.format(
                     "%s\n%s\n",
                     JSON_MAPPER.writeValueAsString(events.get(0)),
                     JSON_MAPPER.writeValueAsString(events.get(1))
-                ),
-                StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )),
+                JSON_MAPPER.readTree(
+                  StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )
             );
 
             return GoHandlers.immediateFuture(okResponse());
@@ -521,12 +527,14 @@ public class EmitterTest
                 request.getHeaders().get(HttpHeaders.Names.CONTENT_TYPE)
             );
             Assert.assertEquals(
-                StringUtils.format(
+                JSON_MAPPER.readTree(StringUtils.format(
                     "[%s,%s]\n",
                     JSON_MAPPER.writeValueAsString(events.get(counter.getAndIncrement())),
                     JSON_MAPPER.writeValueAsString(events.get(counter.getAndIncrement()))
-                ),
-                StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )),
+                JSON_MAPPER.readTree(
+                    StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )
             );
 
             return GoHandlers.immediateFuture(okResponse());
@@ -584,12 +592,14 @@ public class EmitterTest
             CompressionUtils.gunzip(new ByteArrayInputStream(dataArray), baos);
 
             Assert.assertEquals(
-                StringUtils.format(
+                JSON_MAPPER.readTree(StringUtils.format(
                     "[%s,%s]\n",
                     JSON_MAPPER.writeValueAsString(events.get(0)),
                     JSON_MAPPER.writeValueAsString(events.get(1))
-                ),
+                )),
+                JSON_MAPPER.readTree(
                 baos.toString(StandardCharsets.UTF_8.name())
+                )
             );
 
             return GoHandlers.immediateFuture(okResponse());

--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
@@ -155,7 +155,9 @@ public class ParametrizedUriEmitterTest
         "http://example.com/test1", StringUtils.format("[%s]\n", JSON_MAPPER.writeValueAsString(events.get(0))),
         "http://example.com/test2", StringUtils.format("[%s]\n", JSON_MAPPER.writeValueAsString(events.get(1)))
     );
-    Assert.assertEquals(expected, results);
+    for (Map.Entry<String, String> entry : expected.entrySet()) {
+      Assert.assertEquals(JSON_MAPPER.readTree(expected.get(entry.getKey())), JSON_MAPPER.readTree(results.get(entry.getKey())));
+    }
   }
 
   @Test


### PR DESCRIPTION
Fixes #15198, #15199, #15200, #15201, #15202, #15204

These flaky tests have been found using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Plugin. 

### Description

### Fixes flaky test _org.apache.druid.java.util.emitter.core.ParametrizedUriEmitterTest#testEmitterWithMultipleFeeds_
#### ID: #15198

#### Problem: 
```shell
java.lang.AssertionError: 
expected:<{http://example.com/test1=[{"metrics":{"value":1},"feed":"test1"}]
, http://example.com/test2=[{"metrics":{"value":2},"feed":"test2"}]
}> but was:<{http://example.com/test1=[{"feed":"test1","metrics":{"value":1}}]
, http://example.com/test2=[{"feed":"test2","metrics":{"value":2}}]
}>
``` 

This test checks the Equality of two maps, containing the same keys (strings) and values (strings). These values are JSON-String. JSON strings are not unique – they are considered equal if they contain the same elements without taking care of the order of the elements on the same level. The current assertion leads to a flaky test.

#### Solution
To fix this, the strings are getting parsed using the Jackson library and compared to remove the flakiness. 

#### To reproduce run
```shell
mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.java.util.emitter.core.ParametrizedUriEmitterTest#testEmitterWithMultipleFeeds
``` 

<hr>

### Fixes flaky tests _org.apache.druid.java.util.emitter.core.EmitterTest#testSanityWithGeneralizedCreation_ , test _org.apache.druid.java.util.emitter.core.EmitterTest#testSanity_ , _org.apache.druid.java.util.emitter.core.EmitterTest#testGzipContentEncoding_
#### ID: #15199, #15200, #15201

#### Problem: 
```shell
java.lang.RuntimeException: org.junit.ComparisonFailure: expected:<[{"[metrics":{"value":1},"feed":"test"]},{"feed":"test","me...> but was:<[{"[feed":"test","metrics":{"value":1}]},{"feed":"test","me...>
``` 

These tests check for a specific ordering of elements in a JSON string. JSON strings are equal even if the ordering of the elements in the JSON strings are not equal. 

#### Solution
To fix this, the strings are getting parsed using the Jackson library and compared to remove the flakiness. 

#### To reproduce run
```shell
mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=testname
``` 

<hr>
<hr>

### Fixes flaky test _org.apache.druid.java.util.emitter.core.EmitterTest#testBatchSplitting_
#### ID: #15202

#### Problem:
```shell
[ERROR] org.apache.druid.java.util.emitter.core.EmitterTest.testBatchSplitting -- Time elapsed: 6.516 s <<< FAILURE!
java.lang.AssertionError: expected:<2> but was:<0>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at org.apache.druid.java.util.emitter.core.EmitterTest.testBatchSplitting(EmitterTest.java:541)
``` 
This test fails on EmitterTest.java:541, but the actual error is the JSON assertion in the GoHandler again. It checks for a specific ordering of elements in a JSON string. JSON strings are equal even if the ordering of the elements in the JSON strings are not equal. 


#### Solution
To fix this, the strings are getting parsed using the Jackson library and compared to remove the flakiness. 

#### To reproduce run
```shell
mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.java.util.emitter.core.EmitterTest#testBatchSplitting
``` 

<hr>

### Fixes flaky test _org.apache.druid.java.util.emitter.core.EmitterTest#testBasicAuthenticationAndNewlineSeparating_
#### ID: #15204

#### Problem:
```shell
[INFO] Running org.apache.druid.java.util.emitter.core.EmitterTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3.200 s <<< FAILURE! -- in org.apache.druid.java.util.emitter.core.EmitterTest
[ERROR] org.apache.druid.java.util.emitter.core.EmitterTest.testBasicAuthenticationAndNewlineSeparating -- Time elapsed: 3.192 s <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.apache.druid.java.util.emitter.core.EmitterTest.testBasicAuthenticationAndNewlineSeparating(EmitterTest.java:489)
``` 
This test fails in a later line, but the actual error is the JSON assertion in the GoHandler again. It checks for a specific ordering of elements in a JSON string. JSON strings are equal even if the ordering of the elements in the JSON strings are not equal.

#### Solution
To fix this, the strings are getting parsed using the Jackson library and compared to remove the flakiness. 

#### To reproduce run
```shell
mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.java.util.emitter.core.EmitterTest#testBasicAuthenticationAndNewlineSeparating
``` 

<hr>

##### Key changed/added classes in this PR
 * `org.apache.druid.java.util.emitter.core.ParametrizedUriEmitterTest`
 * `org.apache.druid.java.util.emitter.core.EmitterTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
